### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -326,6 +326,10 @@ Matrix provides official Debian packages via apt from http://matrix.org/packages
 Note that these packages do not include a client - choose one from
 https://matrix.org/docs/projects/try-matrix-now.html (or build your own with one of our SDKs :)
 
+Note: For URL previews to work you have to have python-lxml and python-netaddr dependencies installed.
+  
+  sudo apt install python-lxml python-netaddr
+
 Fedora
 ------
 


### PR DESCRIPTION
When using deb package in default if you turn on URL Previews it fails because of unmet dependency.
Error message given says install lxml - pip install lxml

This doesn't help as you need to use apt install python-lxml

It would be nice to have this in docs. 